### PR TITLE
Terminate the process when the window gets closed

### DIFF
--- a/src/NitroSharp/GameContext.cs
+++ b/src/NitroSharp/GameContext.cs
@@ -517,7 +517,10 @@ namespace NitroSharp
             try
             {
                 RenderContext.EndFrame();
-                RenderContext.Present();
+                if (Window.Exists)
+                {
+                    RenderContext.Present();
+                }
             }
             catch (VeldridException e)
                 when (e.Message == "The Swapchain's underlying surface has been lost.")


### PR DESCRIPTION
GraphicsDevice.SwapBuffers() gets stuck if the window was closed before calling it 
(On linux at least, I have not tested it on windows)